### PR TITLE
Passing context to functions passed into withText

### DIFF
--- a/src/components/with-text.js
+++ b/src/components/with-text.js
@@ -44,7 +44,7 @@ import translateMapping from '../lib/translate-mapping';
 export function withText(mapping) {
 	return function withTextWrapper(Child) {
 		return function WithTextWrapper(props, context) {
-			let map = typeof mapping==='function' ? mapping(props) : mapping;
+			let map = typeof mapping==='function' ? mapping(props, context) : mapping;
 			let translations = translateMapping(map, context.intl);
 			return <Child {...props} {...translations} />;
 		};


### PR DESCRIPTION
Passing context to functions passed into withText. This is required for abstractions we have built on top of preact-i18n.

This is not a breaking change, and all tests pass.