### PR TITLE
Add CLDR pluralization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The available forms for specifying pluralization values are as follows:
 
 -   `"key": { "singular":"apple", "plural":"apples" }`
 -   `"key": { "none":"no apples", "one":"apple", "many":"apples" }`
+-   `"key": { "zero":"no apples", "one":"apple", "other":"apples" }`
 -   `"key": ["apples", "apple"]`
 
 Taking `<Text id="news.totalStories" ..>` from our example:

--- a/src/lib/translate.js
+++ b/src/lib/translate.js
@@ -29,7 +29,7 @@ export default function translate(id, scope, dictionary, fields, plural, fallbac
 		if (value.splice) {
 			value = value[plural] || value[0];
 		}
-		else if (plural===0 && defined(value.none)) {
+		else if (plural===0 && defined(value.none || value.zero)) {
 			value = value.none || value.zero;
 		}
 		else if (plural===1 && defined(value.one || value.singular)) {

--- a/src/lib/translate.js
+++ b/src/lib/translate.js
@@ -23,13 +23,14 @@ export default function translate(id, scope, dictionary, fields, plural, fallbac
 	// plural forms:
 	// key: ['plural', 'singular']
 	// key: { none, one, many }
+	// key: { zero, one, other }
 	// key: { singular, plural }
 	if ((plural || plural===0) && value && typeof value==='object') {
 		if (value.splice) {
 			value = value[plural] || value[0];
 		}
 		else if (plural===0 && defined(value.none)) {
-			value = value.none;
+			value = value.none || value.zero;
 		}
 		else if (plural===1 && defined(value.one || value.singular)) {
 			value = value.one || value.singular;

--- a/test/lib/translate.js
+++ b/test/lib/translate.js
@@ -28,6 +28,29 @@ describe('translate', () => {
 	it('should translate <Text /> components that exist in field values when working on templated strings', () => {
 		expect(translate('foo.bar', undefined, { foo: { bar: 'hello{{c.d}}' }, e: 'World' }, { c: { d: <Text id="e" /> } })).to.equal('helloWorld');
 	});
+	
+	it('should pluralise for none/one/many pluralisation keys', () => {
+		expect(translate('foo.bar', undefined, { foo: { none: 'none', one: 'one', many: 'many' } }, undefined, 0)).to.equal('none');
+		expect(translate('foo.bar', undefined, { foo: { none: 'none', one: 'one', many: 'many' } }, undefined, 1)).to.equal('one');
+		expect(translate('foo.bar', undefined, { foo: { none: 'none', one: 'one', many: 'many' } }, undefined, 2)).to.equal('many');
+		expect(translate('foo.bar', undefined, { foo: { none: 'none', one: 'one', many: 'many' } }, undefined, 100)).to.equal('many');
+	});
+	
+	it('should pluralise for zero/one/other pluralisation keys', () => {
+		expect(translate('foo.bar', undefined, { foo: { zero: 'zero', one: 'one', other: 'other' } }, undefined, 0)).to.equal('zero');
+		expect(translate('foo.bar', undefined, { foo: { zero: 'zero', one: 'one', other: 'other' } }, undefined, 1)).to.equal('one');
+		expect(translate('foo.bar', undefined, { foo: { zero: 'zero', one: 'one', other: 'other' } }, undefined, 2)).to.equal('other');
+		expect(translate('foo.bar', undefined, { foo: { zero: 'zero', one: 'one', other: 'other' } }, undefined, 100)).to.equal('other');
+	});
+	
+	it('should pluralise for singular/plural pluralisation keys', () => {
+		// assume 0 is a plural form if using the singular/plural pluralisation convention
+		expect(translate('foo.bar', undefined, { foo: { singular: 'singular', plural: 'plural' } }, undefined, 0)).to.equal('plural');
+		
+		expect(translate('foo.bar', undefined, { foo: { singular: 'singular', plural: 'plural' } }, undefined, 1)).to.equal('singular');
+		expect(translate('foo.bar', undefined, { foo: { singular: 'singular', plural: 'plural' } }, undefined, 2)).to.equal('plural');
+		expect(translate('foo.bar', undefined, { foo: { singular: 'singular', plural: 'plural' } }, undefined, 100)).to.equal('plural');
+	});
 
 
 });

--- a/test/lib/translate.js
+++ b/test/lib/translate.js
@@ -30,26 +30,26 @@ describe('translate', () => {
 	});
 	
 	it('should pluralise for none/one/many pluralisation keys', () => {
-		expect(translate('foo.bar', undefined, { foo: { none: 'none', one: 'one', many: 'many' } }, undefined, 0)).to.equal('none');
-		expect(translate('foo.bar', undefined, { foo: { none: 'none', one: 'one', many: 'many' } }, undefined, 1)).to.equal('one');
-		expect(translate('foo.bar', undefined, { foo: { none: 'none', one: 'one', many: 'many' } }, undefined, 2)).to.equal('many');
-		expect(translate('foo.bar', undefined, { foo: { none: 'none', one: 'one', many: 'many' } }, undefined, 100)).to.equal('many');
+		expect(translate('foo.bar', undefined, { foo: { bar: { none: 'none', one: 'one', many: 'many' } } }, undefined, 0)).to.equal('none');
+		expect(translate('foo.bar', undefined, { foo: { bar: { none: 'none', one: 'one', many: 'many' } } }, undefined, 1)).to.equal('one');
+		expect(translate('foo.bar', undefined, { foo: { bar: { none: 'none', one: 'one', many: 'many' } } }, undefined, 2)).to.equal('many');
+		expect(translate('foo.bar', undefined, { foo: { bar: { none: 'none', one: 'one', many: 'many' } } }, undefined, 100)).to.equal('many');
 	});
 	
 	it('should pluralise for zero/one/other pluralisation keys', () => {
-		expect(translate('foo.bar', undefined, { foo: { zero: 'zero', one: 'one', other: 'other' } }, undefined, 0)).to.equal('zero');
-		expect(translate('foo.bar', undefined, { foo: { zero: 'zero', one: 'one', other: 'other' } }, undefined, 1)).to.equal('one');
-		expect(translate('foo.bar', undefined, { foo: { zero: 'zero', one: 'one', other: 'other' } }, undefined, 2)).to.equal('other');
-		expect(translate('foo.bar', undefined, { foo: { zero: 'zero', one: 'one', other: 'other' } }, undefined, 100)).to.equal('other');
+		expect(translate('foo.bar', undefined, { foo: { bar: { zero: 'zero', one: 'one', other: 'other' } } }, undefined, 0)).to.equal('zero');
+		expect(translate('foo.bar', undefined, { foo: { bar: { zero: 'zero', one: 'one', other: 'other' } } }, undefined, 1)).to.equal('one');
+		expect(translate('foo.bar', undefined, { foo: { bar: { zero: 'zero', one: 'one', other: 'other' } } }, undefined, 2)).to.equal('other');
+		expect(translate('foo.bar', undefined, { foo: { bar: { zero: 'zero', one: 'one', other: 'other' } } }, undefined, 100)).to.equal('other');
 	});
 	
 	it('should pluralise for singular/plural pluralisation keys', () => {
 		// assume 0 is a plural form if using the singular/plural pluralisation convention
-		expect(translate('foo.bar', undefined, { foo: { singular: 'singular', plural: 'plural' } }, undefined, 0)).to.equal('plural');
+		expect(translate('foo.bar', undefined, { foo: { bar: { singular: 'singular', plural: 'plural' } } }, undefined, 0)).to.equal('plural');
 		
-		expect(translate('foo.bar', undefined, { foo: { singular: 'singular', plural: 'plural' } }, undefined, 1)).to.equal('singular');
-		expect(translate('foo.bar', undefined, { foo: { singular: 'singular', plural: 'plural' } }, undefined, 2)).to.equal('plural');
-		expect(translate('foo.bar', undefined, { foo: { singular: 'singular', plural: 'plural' } }, undefined, 100)).to.equal('plural');
+		expect(translate('foo.bar', undefined, { foo: { bar: { singular: 'singular', plural: 'plural' } } }, undefined, 1)).to.equal('singular');
+		expect(translate('foo.bar', undefined, { foo: { bar: { singular: 'singular', plural: 'plural' } } }, undefined, 2)).to.equal('plural');
+		expect(translate('foo.bar', undefined, { foo: { bar: { singular: 'singular', plural: 'plural' } } }, undefined, 100)).to.equal('plural');
 	});
 
 


### PR DESCRIPTION
I have been using Phrase to manage my app translations and they seem to use the CLDR Plural Rules, which have "zero", "one" and "other" as the plural form keys.

It would be nice to include these as well as it doesn't affect the rest of the library and only broadens the support with little overhead.